### PR TITLE
Add C++17 frame processing example

### DIFF
--- a/cpp-interview-example/CMakeLists.txt
+++ b/cpp-interview-example/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+project(cpp_interview_example LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_library(frame_processor
+    src/GrayscaleProcessor.cpp
+)
+
+target_include_directories(frame_processor PUBLIC include)
+
+add_executable(example src/main.cpp)
+
+target_link_libraries(example PRIVATE frame_processor)

--- a/cpp-interview-example/README.md
+++ b/cpp-interview-example/README.md
@@ -1,0 +1,17 @@
+# C++17 Interview Example
+
+This project demonstrates a simple frame processing pipeline using modern C++17 features.
+It showcases object-oriented design, smart pointers, asynchronous execution with `std::async`,
+and a minimal CMake build setup.
+
+The program generates a dummy frame, converts it to grayscale asynchronously, and
+writes the result to `output_frame.bin`.
+
+## Build and Run
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+./example
+```

--- a/cpp-interview-example/include/Frame.h
+++ b/cpp-interview-example/include/Frame.h
@@ -1,0 +1,13 @@
+#ifndef FRAME_H
+#define FRAME_H
+
+#include <vector>
+#include <cstdint>
+
+struct Frame {
+    int width;
+    int height;
+    std::vector<uint8_t> data;
+};
+
+#endif // FRAME_H

--- a/cpp-interview-example/include/GrayscaleProcessor.h
+++ b/cpp-interview-example/include/GrayscaleProcessor.h
@@ -1,0 +1,11 @@
+#ifndef GRAYSCALEPROCESSOR_H
+#define GRAYSCALEPROCESSOR_H
+
+#include "IFrameProcessor.h"
+
+class GrayscaleProcessor : public IFrameProcessor {
+public:
+    void process(Frame& frame) override;
+};
+
+#endif // GRAYSCALEPROCESSOR_H

--- a/cpp-interview-example/include/IFrameProcessor.h
+++ b/cpp-interview-example/include/IFrameProcessor.h
@@ -1,0 +1,12 @@
+#ifndef IFRAMEPROCESSOR_H
+#define IFRAMEPROCESSOR_H
+
+#include "Frame.h"
+
+class IFrameProcessor {
+public:
+    virtual ~IFrameProcessor() = default;
+    virtual void process(Frame& frame) = 0;
+};
+
+#endif // IFRAMEPROCESSOR_H

--- a/cpp-interview-example/src/GrayscaleProcessor.cpp
+++ b/cpp-interview-example/src/GrayscaleProcessor.cpp
@@ -1,0 +1,18 @@
+#include "GrayscaleProcessor.h"
+
+void GrayscaleProcessor::process(Frame& frame) {
+    if (frame.data.size() != static_cast<size_t>(frame.width * frame.height * 3)) {
+        return;
+    }
+
+    for (int y = 0; y < frame.height; ++y) {
+        for (int x = 0; x < frame.width; ++x) {
+            size_t index = static_cast<size_t>((y * frame.width + x) * 3);
+            auto r = frame.data[index];
+            auto g = frame.data[index + 1];
+            auto b = frame.data[index + 2];
+            auto gray = static_cast<uint8_t>((r + g + b) / 3);
+            frame.data[index] = frame.data[index + 1] = frame.data[index + 2] = gray;
+        }
+    }
+}

--- a/cpp-interview-example/src/main.cpp
+++ b/cpp-interview-example/src/main.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+#include <fstream>
+#include <future>
+#include <memory>
+#include <thread>
+#include <algorithm>
+
+#include "GrayscaleProcessor.h"
+
+Frame generateDummyFrame(int width, int height) {
+    Frame frame{width, height, std::vector<uint8_t>(width * height * 3)};
+    std::generate(frame.data.begin(), frame.data.end(), [] { return rand() % 256; });
+    return frame;
+}
+
+void saveFrame(const Frame& frame, const std::string& filename) {
+    std::ofstream out(filename, std::ios::binary);
+    out.write(reinterpret_cast<const char*>(frame.data.data()), frame.data.size());
+}
+
+int main() {
+    constexpr int width = 640;
+    constexpr int height = 480;
+
+    auto processor = std::make_unique<GrayscaleProcessor>();
+    auto frame = std::make_shared<Frame>(generateDummyFrame(width, height));
+
+    auto future = std::async(std::launch::async, [processor = std::move(processor), frame] {
+        processor->process(*frame);
+    });
+
+    future.wait();
+    saveFrame(*frame, "output_frame.bin");
+
+    std::cout << "Frame processed and saved to output_frame.bin" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a small C++17 example project showing asynchronous frame processing
- use an interface and a concrete grayscale processor implementation

## Testing
- `cmake ..`
- `make`
- `./example`


------
https://chatgpt.com/codex/tasks/task_e_68427481a1e0832eb04dc1f3ad592d21